### PR TITLE
[DEV] Android 경로상세 Activity 개선

### DIFF
--- a/app/src/main/java/com/yong/freshroute/activity/DetailActivity.kt
+++ b/app/src/main/java/com/yong/freshroute/activity/DetailActivity.kt
@@ -73,7 +73,7 @@ class DetailActivity : AppCompatActivity() {
     private fun drawRoute(kakaoMap: KakaoMap) {
         val routeLayer = kakaoMap.routeLineManager!!.layer
 
-        val routeStyleBlack = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(android.R.color.black)))
+        val routeStyleBlack = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_black)))
         val routeStyleBlue = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_blue)))
         val routeStyleGreen = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_green)))
         val routeStyleOrange = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_orange)))

--- a/app/src/main/java/com/yong/freshroute/activity/DetailActivity.kt
+++ b/app/src/main/java/com/yong/freshroute/activity/DetailActivity.kt
@@ -73,16 +73,18 @@ class DetailActivity : AppCompatActivity() {
     private fun drawRoute(kakaoMap: KakaoMap) {
         val routeLayer = kakaoMap.routeLineManager!!.layer
 
+        val routeStyleBlack = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(android.R.color.black)))
         val routeStyleBlue = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_blue)))
         val routeStyleGreen = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_green)))
         val routeStyleOrange = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_orange)))
         val routeStyleRed = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_red)))
         val routeStyleYellow = RouteLineStyles.from(RouteLineStyle.from(15f, getColor(R.color.route_yellow)))
-        val routeStyleSet = RouteLineStylesSet.from(routeStyleBlue, routeStyleGreen, routeStyleYellow, routeStyleOrange, routeStyleRed)
+        val routeStyleSet = RouteLineStylesSet.from(routeStyleBlack, routeStyleBlue, routeStyleGreen, routeStyleYellow, routeStyleOrange, routeStyleRed)
 
         val routeLineList: MutableList<RouteLineSegment> = mutableListOf()
         routeData!!.route.steps.forEach {
-            val styleIdx = getRouteStyleIndex(it.distance.toDouble(), it.elevationDelta.toDouble())
+            val styleIdx = if (it.isWalking) getRouteStyleIndex(it.distance.toDouble(), it.elevationDelta.toDouble())
+                            else 0
             val routeCordList: MutableList<LatLng> = mutableListOf()
             for(i in it.wayPoints[0].toInt() .. it.wayPoints[1].toInt()){
                 routeCordList.add(
@@ -102,15 +104,15 @@ class DetailActivity : AppCompatActivity() {
     private fun getRouteStyleIndex(distance: Double, elvDelta: Double): Int{
         val incline = kotlin.math.abs(100 * elvDelta / distance)
         if(incline >= 7){
-            return 4
+            return 5
         }else if(incline >= 5){
-            return 3
+            return 4
         }else if(incline >= 3){
-            return 2
+            return 3
         }else if(incline >= 1){
-            return 1
+            return 2
         }
-        return 0
+        return 1
     }
 
     private fun moveCamera(kakaoMap: KakaoMap, lat: Number, long: Number) {

--- a/app/src/main/java/com/yong/freshroute/adapter/RouteDetailRecyclerAdapter.kt
+++ b/app/src/main/java/com/yong/freshroute/adapter/RouteDetailRecyclerAdapter.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import com.yong.freshroute.R
 import com.yong.freshroute.util.RouteApiResultItemDataStep
+import kotlinx.coroutines.withContext
 
 class RouteDetailRecyclerAdapter(dataList: List<RouteApiResultItemDataStep>): Adapter<RouteDetailRecyclerAdapter.ViewHolder>() {
     private val dataList: List<RouteApiResultItemDataStep>
@@ -38,9 +39,9 @@ class RouteDetailRecyclerAdapter(dataList: List<RouteApiResultItemDataStep>): Ad
         val listItem = dataList[position]
 
         if(listItem.distance != 0 && listItem.duration != 0){
-            holder.tvDescription.text = String.format("Distance : %.1fm / Duration : %.1fs", listItem.distance.toDouble(), listItem.duration.toDouble())
+            holder.tvDescription.text = String.format(holder.itemView.resources.getString(R.string.detail_recycler_route_description), listItem.distance.toDouble(), listItem.duration.toDouble())
         }
-        holder.tvTitle.text = String.format("%s (%s)", listItem.name, listItem.type)
+        holder.tvTitle.text = String.format(holder.itemView.resources.getString(R.string.detail_recycler_route_title), listItem.name, listItem.type)
         holder.itemView.setOnClickListener { view ->
             itemClick?.onClick(view, position)
         }

--- a/app/src/main/java/com/yong/freshroute/adapter/RouteDetailRecyclerAdapter.kt
+++ b/app/src/main/java/com/yong/freshroute/adapter/RouteDetailRecyclerAdapter.kt
@@ -18,16 +18,12 @@ class RouteDetailRecyclerAdapter(dataList: List<RouteApiResultItemDataStep>): Ad
     }
 
     inner class ViewHolder(view: View): RecyclerView.ViewHolder(view) {
-        val tvDistance: TextView
-        val tvDuration: TextView
-        val tvName: TextView
-        val tvType: TextView
+        val tvDescription: TextView
+        val tvTitle: TextView
 
         init {
-            tvDistance = view.findViewById(R.id.recycler_item_routedetail_distance)
-            tvDuration = view.findViewById(R.id.recycler_item_routedetail_duration)
-            tvName = view.findViewById(R.id.recycler_item_routedetail_name)
-            tvType = view.findViewById(R.id.recycler_item_routedetail_type)
+            tvDescription = view.findViewById(R.id.recycler_item_routedetail_description)
+            tvTitle = view.findViewById(R.id.recycler_item_routedetail_title)
         }
     }
 
@@ -40,10 +36,11 @@ class RouteDetailRecyclerAdapter(dataList: List<RouteApiResultItemDataStep>): Ad
 
     override fun onBindViewHolder(holder: RouteDetailRecyclerAdapter.ViewHolder, position: Int) {
         val listItem = dataList[position]
-        holder.tvDistance.text = listItem.distance.toString()
-        holder.tvDuration.text = listItem.duration.toString()
-        holder.tvName.text = listItem.name
-        holder.tvType.text = listItem.type
+
+        if(listItem.distance != 0 && listItem.duration != 0){
+            holder.tvDescription.text = String.format("Distance : %.1fm / Duration : %.1fs", listItem.distance.toDouble(), listItem.duration.toDouble())
+        }
+        holder.tvTitle.text = String.format("%s (%s)", listItem.name, listItem.type)
         holder.itemView.setOnClickListener { view ->
             itemClick?.onClick(view, position)
         }

--- a/app/src/main/java/com/yong/freshroute/util/Interfaces.kt
+++ b/app/src/main/java/com/yong/freshroute/util/Interfaces.kt
@@ -64,6 +64,7 @@ data class RouteApiResultItemDataStep(
     val elevationDelta: Number,
     val type: String,
     val name: String,
+    val isWalking: Boolean
     val wayPoints: List<Number>
 ): Serializable
 

--- a/app/src/main/java/com/yong/freshroute/util/Interfaces.kt
+++ b/app/src/main/java/com/yong/freshroute/util/Interfaces.kt
@@ -64,7 +64,7 @@ data class RouteApiResultItemDataStep(
     val elevationDelta: Number,
     val type: String,
     val name: String,
-    val isWalking: Boolean
+    val isWalking: Boolean,
     val wayPoints: List<Number>
 ): Serializable
 

--- a/app/src/main/res/layout/recycler_item_route_detail.xml
+++ b/app/src/main/res/layout/recycler_item_route_detail.xml
@@ -16,27 +16,8 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="5dp"
             android:layout_marginEnd="5dp"
-            android:id="@+id/recycler_item_routedetail_name"
-            android:text="Name"
-            android:textColor="@android:color/black"
-            android:textSize="17sp" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="5dp"
-            android:layout_marginEnd="5dp"
-            android:text="/"
-            android:textColor="@android:color/black"
-            android:textSize="17sp" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="5dp"
-            android:layout_marginEnd="5dp"
-            android:id="@+id/recycler_item_routedetail_type"
-            android:text="Type"
+            android:id="@+id/recycler_item_routedetail_title"
+            android:text="Title"
             android:textColor="@android:color/black"
             android:textSize="17sp" />
 
@@ -52,27 +33,8 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="5dp"
             android:layout_marginEnd="5dp"
-            android:id="@+id/recycler_item_routedetail_distance"
-            android:text="Distance"
-            android:textColor="@android:color/darker_gray"
-            android:textSize="15sp" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="5dp"
-            android:layout_marginEnd="5dp"
-            android:text="/"
-            android:textColor="@android:color/darker_gray"
-            android:textSize="15sp" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="5dp"
-            android:layout_marginEnd="5dp"
-            android:id="@+id/recycler_item_routedetail_duration"
-            android:text="Duration"
+            android:id="@+id/recycler_item_routedetail_description"
+            android:text="Description"
             android:textColor="@android:color/darker_gray"
             android:textSize="15sp" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,9 +13,10 @@
 
     <color name="cau_blue">#2155A4</color>
 
-    <color name="route_blue">#0000FF</color>
-    <color name="route_green">#00FF00</color>
-    <color name="route_orange">#FF7700</color>
-    <color name="route_red">#FF0000</color>
-    <color name="route_yellow">#FFFF00</color>
+    <color name="route_black">#3A3A3A</color>
+    <color name="route_blue">#1976D2</color>
+    <color name="route_green">#388E3C</color>
+    <color name="route_orange">#FFA000</color>
+    <color name="route_red">#E64A19</color>
+    <color name="route_yellow">#AFB42B</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="noti_toast_no_permission">Location Permission is Needed.</string>
 
     <string name="detail_recycler_route_description">Distance : %.1fm / Duration : %.1fs</string>
+    <string name="detail_recycler_route_title">%s (%s)</string>
 
     <string name="login_btn_google">Login with Google</string>
     <string name="login_noti_fail">Failed to Login</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
 
     <string name="noti_toast_no_permission">Location Permission is Needed.</string>
 
+    <string name="detail_recycler_route_description">Distance : %.1fm / Duration : %.1fs</string>
+
     <string name="login_btn_google">Login with Google</string>
     <string name="login_noti_fail">Failed to Login</string>
 


### PR DESCRIPTION
## Summary
#7 에서 구현한 경로상세 Activity를 개선하였습니다.

## Description
- 대중교통 및 도보에 대한 경로 결과를 적절히 분기하여 표시합니다. 대중교통 경로에 대해서는 경사도 정보 색상을 적용하지 않습니다.
- 도보 경로에 대한 경사도 정보 색상의 시인성을 개선하였습니다. 기존 색상보다 채도를 낮추었습니다.
- 하단 상세경로 RecyclerView의 형식을 개선하였습니다.
<img width="40%" src="https://github.com/Fresh-Route/FreshRoute_Android/assets/12806229/c1eb0bcd-a622-4d61-98a2-04ebd01b8b2c"/>
