### PR TITLE
[FIX] 지점 검색 시 예외처리

### DIFF
--- a/app/src/main/java/com/yong/freshroute/activity/SearchInputActivity.kt
+++ b/app/src/main/java/com/yong/freshroute/activity/SearchInputActivity.kt
@@ -82,6 +82,8 @@ class SearchInputActivity : AppCompatActivity() {
                                 return
                             }else{
                                 val resultList = response.body()!!.dataList
+                                resultList.removeIf{it.localAddress.isEmpty()}
+
                                 if(resultList.isEmpty()){
                                     Toast.makeText(applicationContext, getString(R.string.searchinput_noti_no_result), Toast.LENGTH_LONG).show()
                                     return

--- a/app/src/main/java/com/yong/freshroute/util/RetrofilInterfaces.kt
+++ b/app/src/main/java/com/yong/freshroute/util/RetrofilInterfaces.kt
@@ -16,7 +16,7 @@ data class KakaoLocalItem(
 )
 
 data class KakaoLocalList(
-    @SerializedName("documents") val dataList: List<KakaoLocalItem>
+    @SerializedName("documents") val dataList: MutableList<KakaoLocalItem>
 )
 
 interface KakaoLocalAPI {


### PR DESCRIPTION
## Summary
SearchInputActivity에 예외사항을 추가적으로 처리하였습니다.

## Description
- SearchInputActivity에서 출발지 및 도착지를 검색하는 경우, Kakao Local API에서 반환하는 정보들 중, 주소가 `null`인 경우의 항목을 렌더링하지 않도록 예외처리하였습니다.